### PR TITLE
Update ExileServer_util_time_uptime.sqf

### DIFF
--- a/Overrides/ExileServer_util_time_uptime.sqf
+++ b/Overrides/ExileServer_util_time_uptime.sqf
@@ -9,4 +9,4 @@
  * To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-nd/4.0/.
  */
  
-(call compile ("extDB3" callExtension "9:UPTIME:MINUTES")) select 1
+(call compile ("extDB3" callExtension "9:UPTIME:MINUTES"))


### PR DESCRIPTION
extDB3 changed return format for UPTIME (impossible for it to error out without user error). 
Will update documentation later.